### PR TITLE
Update DAB+ Support Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Software  | Initial launch with Android™ 14
 
 Advanced  | Spec Sheet
 ---------:|:-------------------------
-DAB+      | Supported
+DAB+      | [Support postponed](https://www.etsi.org/deliver/etsi_TS/102500_102599/102563/02.01.01_60/ts_102563v020101p.pdf)
 Display   | [DP over USB-C supported](https://www.displayport.org/displayport-over-usb-c/)
 
 ## License


### PR DESCRIPTION
Our test device does not appear to support DAB+ and other users in the [forum](https://forum.shiftphones.com/threads/radio.7740/) confirm the postponed support